### PR TITLE
Add "still"

### DIFF
--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -1,6 +1,6 @@
 {
     "extensionName": {
-      "message": "I don't care about cookies",
+      "message": "I still don't care about cookies",
       "description": "Name of the extension."
     },
     


### PR DESCRIPTION
The new version of the Chinese translation lacks the word "still" in the title. 
I added it.