### PR TITLE
Changed insertCSS origin to user so it has higher priority.

### DIFF
--- a/src/data/context-menu.js
+++ b/src/data/context-menu.js
@@ -555,6 +555,7 @@ function insertCSS(injection, callback) {
         target: { tabId: tabId, frameIds: [frameId || 0] },
         css: css,
         files: file ? [file] : undefined,
+        origin: "USER",
       },
       callback
     );
@@ -566,6 +567,7 @@ function insertCSS(injection, callback) {
         code: css,
         frameId: frameId || 0,
         runAt: xmlTabs[tabId] ? "document_idle" : "document_start",
+        cssOrigin: "user",
       },
       callback
     );


### PR DESCRIPTION
At the moment the css rules we inject are on a lower priority so if a existing css uses !important as well there is no easy way to override it.


