### PR TITLE
Fixed issues with iframeconsents. 

### DIFF
--- a/src/data/background.js
+++ b/src/data/background.js
@@ -551,7 +551,7 @@ chrome.webNavigation.onCommitted.addListener(function (tab) {
   doTheMagic(tab.tabId);
 });
 
-chrome.webRequest.onResponseStarted.addListener(
+chrome.webRequest.onCompleted.addListener(
   function (tab) {
     if (tab.frameId > 0) {
       doTheMagic(tab.tabId, tab.frameId);


### PR DESCRIPTION
Before it was trying to execute the scripts for iframe on the ``onResponseStarted`` sadly this doesn't work correctly since it will be ``about::blank``  until it's fully loaded which we aren't allowed to inject into. Moving it to ``onCompleted``  since that might be a bit slower but it's reliable which I prefer since at the moment it's a bit of RNG if it works or not.


This is most likely also the reason of the reports like t3n.de & zeit.de etc. 
