### PR TITLE
Fix theguardian.com

### DIFF
--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -14981,11 +14981,11 @@ const rules = {
   "merkur.si": { j: "5" },
   "merkur.dk": { j: "5" },
   "theguardian.com": {
-    s: 'div[data-island="cookie-banner"],#cmpContainer,body > #cmp,#bottom-banner,div[x-data*="showCookieBanner"]{display:none !important}',
+    s: 'div[id^="sp_message_container_"]{display:none !important}',
     j: "5",
   },
   "theguardian.com.": {
-    s: 'div[data-island="cookie-banner"],#cmpContainer,body > #cmp,#bottom-banner,div[x-data*="showCookieBanner"]{display:none !important}',
+    s: 'div[id^="sp_message_container_"]{display:none !important}',
     j: "5",
   },
   "kungahuset.se": { j: "5" },


### PR DESCRIPTION
fixes #472

I'm not entirely sure what the other css rules are for, they might be old, but removing them didn't seem to have an effect. I could also not find the elements belonging to the removed css rules using the css selector