### PR TITLE
Update rule for kick.com to support theater mode

### DIFF
--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -15972,7 +15972,7 @@ const rules = {
   "bionic-reading.com": { j: "3" },
   "starnecker.com": { c: 6 },
   "aikikai.de": { c: 14 },
-  "kick.com": { s: "#app > .fixed{display:none !important}" },
+  "kick.com": { s: "#app > .main-html + .fixed{display:none !important}" },
   "primus-apotheken-stadecken.de": {
     s: "#ccModal{display:none !important}",
     c: 14,


### PR DESCRIPTION
The rule for kick.com is too generic and is hiding the player in theater mode. This commit makes the rule specific enough to only hide the cookie notice.