### PR TITLE
Remove coop.co.uk rule that breaks site functionality and is redundant

### DIFF
--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -4222,7 +4222,6 @@ const rules = {
   "iqoption.com": {
     s: 'div[data-test-id="notification-position-container-block"]{display:none !important}',
   },
-  "coop.co.uk": { s: "footer ~ div{display:none !important}" },
   "flows.be": { s: "#flows-cookie-compliance-popup{display:none !important}" },
   "netflixinbelgie.be": { c: 144 },
   "fansbreak.com": { c: 0 },


### PR DESCRIPTION
This rule breaks functionality on coop.co.uk sites such as non-cookie-related modals. 

`footer ~ div{display:none !important}` is a very heavy-handed CSS rule (hide _any_ `div` element that appears in the source order after a `footer` element). It was breaking modal functionality across the whole site, even modals not related to cookie prompts. React modals are often added to the very end of the `body` element, and this means they appear after the footer. The CSS rule hid the modals, which prevented at least one `*.coop.co.uk` site from functioning correctly.

This does not affect the functionality of the extension as that custom rule is redundant. Since it was added Co-op have switched to using OneTrust, so this extension's existing code for handling OneTrust is enough (see screenshot).

Disclosure: I work as a developer at Co-op, but I am also a user of this extension and appreciate it. I discovered this issue while investigating why I couldn't access the website that I am the tech lead for on my personal Chrome profile, but I could access it on my work Chrome profile 😁

<img width="1840" alt="SCR-20230812-rrnh" src="https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/assets/6339853/2f051124-c930-4bc4-999e-487f4255e813">

