### PR TITLE
Add `language` key to anonymous reports

### DIFF
--- a/src/data/background.js
+++ b/src/data/background.js
@@ -391,6 +391,7 @@ function reportWebsite(info, tab, anon, issueType, notes, callback) {
         notes,
         url: tab.url,
         browser: getBrowserAndVersion(),
+        language: navigator.language,
         extensionVersion: chrome.runtime.getManifest().version,
       }),
     })

--- a/src/data/background.js
+++ b/src/data/background.js
@@ -391,7 +391,7 @@ function reportWebsite(info, tab, anon, issueType, notes, callback) {
         notes,
         url: tab.url,
         browser: getBrowserAndVersion(),
-        language: navigator.language,
+        language: navigator.language || Intl.DateTimeFormat().resolvedOptions().locale,
         extensionVersion: chrome.runtime.getManifest().version,
       }),
     })

--- a/src/data/background.js
+++ b/src/data/background.js
@@ -391,7 +391,8 @@ function reportWebsite(info, tab, anon, issueType, notes, callback) {
         notes,
         url: tab.url,
         browser: getBrowserAndVersion(),
-        language: navigator.language || Intl.DateTimeFormat().resolvedOptions().locale,
+        language:
+          navigator.language || Intl.DateTimeFormat().resolvedOptions().locale,
         extensionVersion: chrome.runtime.getManifest().version,
       }),
     })


### PR DESCRIPTION
As mentioned in #11003 - localized pages sometimes renders different content based on language/country. This PR adds a `language` key to the anonymous reports so maintainers can test if it is a localization-related issue. I will also make a PR to the API repo if this gets accepted to grab the reporters country, and place the two pieces of data in the GitHub issues.

Granted, these requests are supposed to be anonymous in nature, but I think we can do this as the bare-minimum to help maintainers find the issue faster, rather than parsing the URL paths. Let me know what you think.