### PR TITLE
docs: fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,9 @@
 
 #### Get rid of cookie warnings from almost all websites!
 
-<a href="https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/releases/latest">
-      <img alt="Latest release" src="https://img.shields.io/github/v/release/OhMyGuus/I-Still-Dont-Care-About-Cookies.svg?logo=github&style=for-the-badge">
-</a>
-<a href="https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/releases">
-      <img alt="Releases" src="https://img.shields.io/github/downloads/OhMyGuus/I-Still-Dont-Care-About-Cookies/total?color=blue&label=downloads&style=for-the-badge">
-</a>
-<a href="LICENSE">
-      <img alt="License: GPL v3" src="https://img.shields.io/badge/License-GPLv3-blue.svg?style=for-the-badge">
-</a>
+<a href="https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/OhMyGuus/I-Still-Dont-Care-About-Cookies.svg?logo=github&style=for-the-badge"></a>
+<a href="https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/releases"><img alt="Releases" src="https://img.shields.io/github/downloads/OhMyGuus/I-Still-Dont-Care-About-Cookies/total?color=blue&label=downloads&style=for-the-badge"></a>
+<a href="LICENSE"><img alt="License: GPL v3" src="https://img.shields.io/badge/License-GPLv3-blue.svg?style=for-the-badge"></a>
 
 </div>
 
@@ -28,15 +22,9 @@ This extension has been acquired by _**[Avast](https://en.wikipedia.org/wiki/Ava
 
 ## Download & Install
 
-<a href="https://addons.mozilla.org/en-US/firefox/addon/istilldontcareaboutcookies">
-  <img src="https://blog.mozilla.org/addons/files/2020/04/get-the-addon-fx-apr-2020.svg" alt='Get the Extension on Firefox' height="75">
-</a>
-<a href="https://chrome.google.com/webstore/detail/i-still-dont-care-about-c/edibdbjcniadpccecjdfdjjppcpchdlm">
-  <img src="https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iNEddTyWiMfLSwFD6qGq.png" alt="Get the Extesion on Chrome" height="75" style="border: 1px solid transparent; border-radius:6px;">
-</a>
-<a href="https://microsoftedge.microsoft.com/addons/detail/i-still-dont-care-about-/kkacdgacpkediooahopgcbdahlpipheh">
-  <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Get_it_from_Microsoft_Badge.svg/320px-Get_it_from_Microsoft_Badge.svg.png" alt="Get the Extension on Edge" height="75" style="border: 1px solid transparent; border-radius:4px;">
-</a>
+<a href="https://addons.mozilla.org/en-US/firefox/addon/istilldontcareaboutcookies"><img src="https://blog.mozilla.org/addons/files/2020/04/get-the-addon-fx-apr-2020.svg" alt='Get the Extension on Firefox' height="75"></a>
+<a href="https://chrome.google.com/webstore/detail/i-still-dont-care-about-c/edibdbjcniadpccecjdfdjjppcpchdlm"><img src="https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/iNEddTyWiMfLSwFD6qGq.png" alt="Get the Extesion on Chrome" height="75" style="border: 1px solid transparent; border-radius:6px;"></a>
+<a href="https://microsoftedge.microsoft.com/addons/detail/i-still-dont-care-about-/kkacdgacpkediooahopgcbdahlpipheh"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Get_it_from_Microsoft_Badge.svg/320px-Get_it_from_Microsoft_Badge.svg.png" alt="Get the Extension on Edge" height="75" style="border: 1px solid transparent; border-radius:4px;"></a>
 
 ## Manual installation
 


### PR DESCRIPTION
The badges render with a weird blue underline b/w them. This commit fixes that.

Issue: 
![image](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/assets/68184623/389ea6a6-7e0d-45e6-8ba9-f9690ee96777)

Fix: 
![image](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/assets/68184623/411fe406-ab3e-4c3b-9910-4bf50e706edf)

Fixed this issue for all the badges in the readme