### PR TITLE
Add channel4 rule to remove overflow from body

### DIFF
--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -329,6 +329,7 @@ const rules = {
   "cofunds.co.uk": {
     s: "#idrMasthead .idrPageRow .smContainer{display:none !important}",
   },
+  "channel4.com": { s: "body { overflow: auto !important; }" },
   "channelregister.co.uk": { s: "#RegCCO{display:none !important}" },
   "ordnancesurvey.co.uk": { s: "#messages{display:none !important}" },
   "hrportfolio.hr": { s: "#kolac{display:none}" },


### PR DESCRIPTION
Fix for Cookie Banner on [channel4.com](https://channel4.com/)

This pull request removes the `overflow: hidden` rule from the body on channel4. The cookie banner is hidden already, but the site is not usable without the overlow removed too.

## 🖼️ Before

<img width="1060" height="228" alt="image" src="https://github.com/user-attachments/assets/b05f8d3f-6473-4e9e-9a98-4f2056c15d85" />

## ✅ After

<img width="1057" height="225" alt="image" src="https://github.com/user-attachments/assets/dff7cfd9-2daf-41da-9a6a-b6e2a8a4a45c" />

## 💅 CSS Applied

`body { overflow: auto !important; }`


Fixes #14707
Fixes #14270
Fixes #3237