### PR TITLE
Change reporting to just the hostname

### DIFF
--- a/src/data/background.js
+++ b/src/data/background.js
@@ -389,7 +389,7 @@ function reportWebsite(info, tab, anon, issueType, notes, callback) {
       body: JSON.stringify({
         issueType,
         notes,
-        url: tab.url,
+        url: hostname,
         browser: getBrowserAndVersion(),
         language:
           navigator.language || Intl.DateTimeFormat().resolvedOptions().locale,


### PR DESCRIPTION
Currently the full url was send to the api, where it was stripped since I was planning to use it before to analyze the full page.
I never saved/done anything with this and since it's a bit of a privacy thingy since it can have sentitive information I'm revering this back to just the hostname. 