### PR TITLE
Updated Privacy Policy to contain "more" information

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -16,7 +16,7 @@ We value your privacy and collect as little data as possible.
 - **When Using the “Report Anonymously” Functionality:**
   In that case, the extension collects and stores only the following minimal, non-personal data:
   - The **hostname** of the website you reported
-  - The **browser used** (e.g., Chrome, Edge, FireFox)
+  - The **browser used** (e.g., Chrome, Edge, Firefox)
   - The **version number** of the extension
   - **Any notes you voluntarily provide** when submitting the report
 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -10,16 +10,15 @@ This extension automatically hides or dismisses cookie consent banners on websit
 
 We value your privacy and collect as little data as possible.
 
-* **Normal Usage:**
+- **Normal Usage:**
   During normal use of the extension, we do **not** collect, store, or share any personal or identifiable information. All processing occurs locally within your browser.
 
-* **When Using the “Report Anonymously” Functionality:**
+- **When Using the “Report Anonymously” Functionality:**
   In that case, the extension collects and stores only the following minimal, non-personal data:
-
-  * The **hostname** of the website you reported
-  * The **browser used** (e.g., Chrome, Edge, FireFox)
-  * The **version number** of the extension
-  * **Any notes you voluntarily provide** when submitting the report
+  - The **hostname** of the website you reported
+  - The **browser used** (e.g., Chrome, Edge, FireFox)
+  - The **version number** of the extension
+  - **Any notes you voluntarily provide** when submitting the report
 
   This information helps us diagnose compatibility issues, improve site handling, and better understand user feedback.
   No other data — such as your IP address, browsing history, or personal identifiers — is collected or stored.

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -13,7 +13,7 @@ We value your privacy and collect as little data as possible.
 - **Normal Usage:**
   During normal use of the extension, we do **not** collect, store, or share any personal or identifiable information. All processing occurs locally within your browser.
 
-- **When Using the “Report Anonymously” Functionality:**
+- **When Using the “Report" Functionality:**
   In that case, the extension collects and stores only the following minimal, non-personal data:
   - The **hostname** of the website you reported
   - The **browser used** (e.g., Chrome, Edge, Firefox)
@@ -40,7 +40,7 @@ This extension does **not** use analytics, tracking scripts, advertising service
 
 ## Data Security
 
-We take reasonable measures to protect any data collected through the “Report Anonymously” feature from unauthorized access or disclosure.
+We take reasonable measures to protect any data collected through the “Report feature from unauthorized access or disclosure.
 
 ## Children’s Privacy
 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,11 +1,58 @@
-## Privacy Policy
+# Privacy Policy
 
-We value your privacy and are committed to protecting it. We do not collect any personal information from our users. We do not store or transmit your personal details, and we do not use any advertising or analytics software that talks to third parties.
+**Effective Date:** November 3, 2025
 
-### Information We Collect
+## Purpose
 
-We do not collect any personal information from our users.
+This extension automatically hides or dismisses cookie consent banners on websites, improving your browsing experience.
 
-### Contact Us
+## Data Collection
 
-If you have any questions or concerns about our privacy policy, please contact us at privacy@istilldontcareaboutcookies.com or through a Github issue on https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/. We will be happy to assist you.
+We value your privacy and collect as little data as possible.
+
+* **Normal Usage:**
+  During normal use of the extension, we do **not** collect, store, or share any personal or identifiable information. All processing occurs locally within your browser.
+
+* **When Using the “Report Anonymously” Functionality:**
+  In that case, the extension collects and stores only the following minimal, non-personal data:
+
+  * The **hostname** of the website you reported
+  * The **browser used** (e.g., Chrome, Edge, FireFox)
+  * The **version number** of the extension
+  * **Any notes you voluntarily provide** when submitting the report
+
+  This information helps us diagnose compatibility issues, improve site handling, and better understand user feedback.
+  No other data — such as your IP address, browsing history, or personal identifiers — is collected or stored.
+
+## Data Storage and Retention
+
+Reports are securely stored on our servers for analysis and improvement purposes only.
+We do not share or sell this data to any third parties.
+Data is retained only as long as necessary for debugging or improvement, then permanently deleted.
+
+## Permissions
+
+The permissions requested by this extension are used solely for its intended functionality (e.g., hiding or removing cookie banners).
+These permissions do **not** grant access to personal data or browsing activity beyond what is necessary for operation.
+
+## Third-Party Access
+
+This extension does **not** use analytics, tracking scripts, advertising services, or any other third-party integrations.
+
+## Data Security
+
+We take reasonable measures to protect any data collected through the “Report Anonymously” feature from unauthorized access or disclosure.
+
+## Children’s Privacy
+
+The extension does not knowingly collect or store any data related to minors.
+
+## Changes to This Policy
+
+We may update this Privacy Policy to reflect improvements or regulatory requirements. Updates will be posted on the Chrome Web Store listing page and/or our official website.
+
+## Contact
+
+If you have any questions or concerns about this Privacy Policy, please contact us at:
+**Email:** privacy@istilldontcareaboutcookies.com
+**Github:** https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies/issues/new


### PR DESCRIPTION
Google Chrome rejected our previous privacy policy after submitting version 1.1.7 (for some reason it became a problem without any real changes after 1.1.5 but fine)
I've reformatted and rewritten it to clearly describe our data collection practices, which is nothing except when you report a cookie consent warning ona site then the following things are collected and placed into a comment on github:

* The **hostname** of the reported website
* The **browser used** (e.g., Chrome, Edge, Firefox)
* The **extension version number**
* **Any notes you include** in the report

