### PR TITLE
Fixed rule for tradingview.com

### DIFF
--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -7122,7 +7122,7 @@ const rules = {
     s: "[data-widget=cookieBubble],.uw_f1a,.p3.p4{display:none!important}",
   },
   "head-fi.org": { c: 11 },
-  "tradingview.com": { s: "#overlap-manager-root{display:none!important}" },
+  "tradingview.com": { s: ".toastCommonBase-zMOxH_8U{display:none!important}" },
   "pcmweb.nl": { j: "5" },
   "webastoconnect.com": { s: ".alert.ecc.show-ecc{display:none !important}" },
   "jobnet.dk": { j: "5" },


### PR DESCRIPTION
Original rule prevented the site's navigation menu from opening. This rule targets only the cookie consent banner.