### PR TITLE
Add support for Phenom People career platform GDPR cookie dialog

### DIFF
--- a/src/data/js/0_defaultClickHandler.js
+++ b/src/data/js/0_defaultClickHandler.js
@@ -204,6 +204,9 @@
       "#bccs-buttonDoNotAgree",
       "#bccs-buttonAgreeRequired:first-child",
     ],
+
+    // Phenom People career platform GDPR dialog (used by 700+ employers)
+    '[key-role="gdpr-regionRole"]': ["button.primary-button"],
   };
 
   const searchGroups = [


### PR DESCRIPTION
## Summary

[Phenom People](https://www.phenom.com/) is a major career platform powering job portals for 700+ employers worldwide (e.g. Strategy&/PwC, Mastercard, UCB, Deutsche Telekom). Their career sites use a standardized GDPR cookie consent dialog that can be identified by the `key-role="gdpr-regionRole"` attribute.

This PR adds a `searchPairs` entry to the default click handler (`0_defaultClickHandler.js`) to automatically dismiss these cookie dialogs by clicking the decline button (`button.primary-button`).

## Changes

- Added a new `searchPairs` entry in `0_defaultClickHandler.js`:
  - **Container selector:** `[key-role="gdpr-regionRole"]` (unique to Phenom People GDPR dialogs)
  - **Button selector:** `button.primary-button` (the decline/reject button)

## Test URLs

- https://jobs.strategyand.pwc.de/
- https://careers.mastercard.com/
- https://careers.ucb.com/

All three sites show the Phenom People GDPR cookie dialog that this rule dismisses.