### PR TITLE
Fix scaleway.com

### DIFF
--- a/src/data/js/5_clickHandler.js
+++ b/src/data/js/5_clickHandler.js
@@ -3203,10 +3203,7 @@ function getSelector(host) {
     case "revolut.com":
       return 'div[class*="CookieConsentModal"] button + button';
     case "scaleway.com":
-      return _if(
-        '#modal a[href*="cookie-policy"]',
-        "#modal button + div button:first-child"
-      );
+      return '#portal [class*="cookieConsentDialog"] button:first-child';
     case "ubiwayretail.be":
       return ".modal.is-open .mod-cookiewarning:first-child";
     case "ammerlaender-versicherung.de":

--- a/src/data/js/6_cookieHandler.js
+++ b/src/data/js/6_cookieHandler.js
@@ -467,12 +467,6 @@ function getE(hostname) {
       return [
         "tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Bing%20Ads%22:false%2C%22Facebook%20Pixel%22:false%2C%22Google%20AdWords%20New%22:false%2C%22Google%20Cloud%20PubSub%22:false%2C%22Google%20Tag%20Manager%22:false%2C%22PERSONAS%20-%20Google%20AdWords%22:false}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:false}}",
       ];
-    case "scaleway.com":
-      return [
-        "consent-advertising=false",
-        "consent-analytics=false",
-        "consent-marketing=false",
-      ];
     case "deckardpenfield.com":
       return [
         'webkitconstent={"technical":true,"ad_storage":false,"analytics_storage":false,"personalization_storage":false}',

--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -15562,7 +15562,7 @@ const rules = {
     s: "#cookieModal{display:none !important}",
     c: 14,
   },
-  "scaleway.com": { j: "6" },
+  "scaleway.com": { j: "5" },
   "fresh-pool.de": { c: 14 },
   "vakin.se": {
     s: 'div[data-testid="modal-backdrop"],.sv-cookie-consent-modal{display:none !important} body{overflow: unset !important; position: unset !important}',


### PR DESCRIPTION
Updates the existing scaleway.com rule to use the click handler instead of writing legacy consent cookies that the current site no longer reads.

The new selector clicks the current cookie consent dialog's first action, which is the reject/necessary-only path, so the site can persist its current consent state and dismiss the banner normally.

Fixes #21144.
Related: #16122, #15700, #13974, #8804.

This is an alternative to the open CSS-hide PRs for scaleway.com; it avoids leaving the app's own consent state unresolved.

Validation:
- npm run lint -- --quiet