### PR TITLE
Added rule for ugyfelszolgalat.szegedivizmu.hu

### DIFF
--- a/src/data/js/6_cookieHandler.js
+++ b/src/data/js/6_cookieHandler.js
@@ -832,6 +832,8 @@ function getE(hostname) {
         "inccookiesconsent=false",
         'inccookiesparams={"all_cookies":false,"cookies_iframes":false,"cookies_matomo":false,"cookies_social_network_facebook":false,"cookies_social_network_linkedin":false,"cookies_social_network_twitter":false}',
       ];
+    case "ugyfelszolgalat.szegedivizmu.hu":
+      return ["cookieConsentAccepted=functional,necessary"];
   }
 
   const parts = hostname.split(".");

--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -20590,6 +20590,7 @@ const rules = {
   "smartial.net": {
     s: ".pcb { display: none !important; } html, body { overflow: auto !important; }",
   },
+  "ugyfelszolgalat.szegedivizmu.hu": { j: "6" },
 
   // end of const rules
 };


### PR DESCRIPTION
The site doesn't let you log in unless you accept the functional and necessary cookies first, but the modal to do this won't appear when using the addon either.