### PR TITLE
add arcraiders.com using css

### DIFF
--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -20590,6 +20590,9 @@ const rules = {
   "smartial.net": {
     s: ".pcb { display: none !important; } html, body { overflow: auto !important; }",
   },
+  "arcraiders.com": {
+    s: "div[data-testid=cookie-banner-root]{display:none!important}",
+  },
 
   // end of const rules
 };


### PR DESCRIPTION
Adds a CSS rule to hide the cookie consent popup on arcraiders.com.

Fixes: #24557

