### PR TITLE
Added rule for minecraft-serverlist.com

### DIFF
--- a/src/data/rules.js
+++ b/src/data/rules.js
@@ -20590,6 +20590,9 @@ const rules = {
   "smartial.net": {
     s: ".pcb { display: none !important; } html, body { overflow: auto !important; }",
   },
+  "minecraft-serverlist.com": {
+    s: "div.cookies[role='dialog']{display:none !important;}",
+  },
 
   // end of const rules
 };


### PR DESCRIPTION
Adds a CSS rule to hide the cookie consent popup on minecraft-serverlist.com.

Fixes: #24552