### PR TITLE
update rule for scaleway.com

### DIFF
--- a/src/data/js/6_cookieHandler.js
+++ b/src/data/js/6_cookieHandler.js
@@ -468,11 +468,7 @@ function getE(hostname) {
         "tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Bing%20Ads%22:false%2C%22Facebook%20Pixel%22:false%2C%22Google%20AdWords%20New%22:false%2C%22Google%20Cloud%20PubSub%22:false%2C%22Google%20Tag%20Manager%22:false%2C%22PERSONAS%20-%20Google%20AdWords%22:false}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:false}}",
       ];
     case "scaleway.com":
-      return [
-        "consent-advertising=false",
-        "consent-analytics=false",
-        "consent-marketing=false",
-      ];
+      return ["_scw_rgpd_hash=2127552167"];
     case "deckardpenfield.com":
       return [
         'webkitconstent={"technical":true,"ad_storage":false,"analytics_storage":false,"personalization_storage":false}',


### PR DESCRIPTION
Fixed the cookie rule to hide the cookie consent popup on scaleway.com.
(The previous rule no longer works due to changes on the website.)

Fixes: #24672