### PR TITLE
Fix incomplete rule tool inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Get rid of cookie warnings from almost all websites!",
   "main": "index.js",
   "scripts": {
+    "test": "node --test",
     "lint": "eslint src .",
     "lintfix": "eslint src --fix",
     "prettier": "prettier --write .",

--- a/src/rules.json
+++ b/src/rules.json
@@ -19897,5 +19897,77 @@
       "resourceTypes": ["script", "stylesheet", "xmlhttprequest", "image"],
       "initiatorDomains": ["saechsische.de"]
     }
+  },
+  {
+    "id": 1735,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "thirstylettuce.com",
+      "resourceTypes": ["script", "stylesheet", "xmlhttprequest", "image"],
+      "initiatorDomains": ["thewindowsclub.com"]
+    }
+  },
+  {
+    "id": 1736,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "spellsalsa.com",
+      "resourceTypes": ["script", "stylesheet", "xmlhttprequest", "image"],
+      "initiatorDomains": ["interestingengineering.com"]
+    }
+  },
+  {
+    "id": 1737,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "cmp.",
+      "resourceTypes": ["script", "stylesheet", "xmlhttprequest", "image"],
+      "initiatorDomains": ["svd.se"]
+    }
+  },
+  {
+    "id": 1738,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "cmp.",
+      "resourceTypes": ["script", "stylesheet", "xmlhttprequest", "image"],
+      "initiatorDomains": ["e24.no"]
+    }
+  },
+  {
+    "id": 1739,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "/c22cs.js",
+      "resourceTypes": ["script", "stylesheet", "xmlhttprequest", "image"],
+      "initiatorDomains": ["cd.cz"]
+    }
+  },
+  {
+    "id": 1740,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "cmp.",
+      "resourceTypes": ["script", "stylesheet", "xmlhttprequest", "image"],
+      "initiatorDomains": ["vg.no"]
+    }
   }
 ]

--- a/tools/add-rule.js
+++ b/tools/add-rule.js
@@ -3,7 +3,7 @@
 import { program } from "commander";
 import * as fs from "fs";
 import * as path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { formatFile } from "./prettier.js";
 import * as acorn from "acorn";
 
@@ -47,7 +47,7 @@ function findPropertyByKey(objectExpression, domain) {
   return null;
 }
 
-function buildRuleEntry(
+export function buildRuleEntry(
   domain,
   css,
   common,
@@ -56,8 +56,8 @@ function buildRuleEntry(
   indent = "  "
 ) {
   const props = {
-    ...(handler && { j: handler }),
-    ...(common && { c: common }),
+    ...(handler !== undefined && { j: handler }),
+    ...(common !== undefined && { c: common }),
     ...(css && { s: JSON.stringify(css) }),
   };
 
@@ -212,4 +212,9 @@ program
     );
   });
 
-program.parse();
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  program.parse();
+}

--- a/tools/generate-block-rules.js
+++ b/tools/generate-block-rules.js
@@ -1,8 +1,9 @@
 // This is used to generate the block rules for Manifest V3 from the block rules in Manifest V2.
 
 import { blockUrls } from "../src/data/rules.js";
+import { pathToFileURL } from "url";
 
-function generateDeclarativeNetRules() {
+export function generateDeclarativeNetRules(source = blockUrls) {
   const result = [];
   let lastId = 1;
 
@@ -24,31 +25,46 @@ function generateDeclarativeNetRules() {
     result.push(newRule);
   };
 
-  for (const blockRule of blockUrls.common) {
+  const addSpecificRule = (domain, url) => {
+    result.push({
+      id: lastId++,
+      priority: 1,
+      action: { type: "block" },
+      condition: {
+        urlFilter: url,
+        resourceTypes: ["script", "stylesheet", "xmlhttprequest", "image"],
+        initiatorDomains: [domain],
+      },
+    });
+  };
+
+  for (const blockRule of source.common) {
     addRule(blockRule);
   }
 
-  for (const blockRules of Object.values(blockUrls.common_groups)) {
+  for (const blockRules of Object.values(source.common_groups)) {
     for (const blockRule of blockRules) {
       addRule(blockRule);
     }
   }
 
-  for (const [domain, url] of Object.entries(blockUrls.specific)) {
-    const newRule = {
-      id: lastId++,
-      priority: 1,
-      action: { type: "block" },
-      condition: {
-        urlFilter: url[0],
-        resourceTypes: ["script", "stylesheet", "xmlhttprequest", "image"],
-        initiatorDomains: [domain],
-      },
-    };
-    result.push(newRule);
+  const additionalSpecificRules = [];
+  for (const [domain, urls] of Object.entries(source.specific)) {
+    addSpecificRule(domain, urls[0]);
+    additionalSpecificRules.push(...urls.slice(1).map((url) => [domain, url]));
   }
 
-  console.log(JSON.stringify(result, null, "\t"));
+  // Keep existing IDs stable and append filters that the old generator skipped.
+  for (const [domain, url] of additionalSpecificRules) {
+    addSpecificRule(domain, url);
+  }
+
+  return result;
 }
 
-generateDeclarativeNetRules();
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  console.log(JSON.stringify(generateDeclarativeNetRules(), null, "\t"));
+}

--- a/tools/rule-tools.test.js
+++ b/tools/rule-tools.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildRuleEntry } from "./add-rule.js";
+import { generateDeclarativeNetRules } from "./generate-block-rules.js";
+
+test("buildRuleEntry preserves zero-valued rule references", () => {
+  assert.equal(
+    buildRuleEntry("example.com", undefined, undefined, 0),
+    '  "example.com": { j: 0 },'
+  );
+  assert.equal(
+    buildRuleEntry("example.com", undefined, 0, undefined),
+    '  "example.com": { c: 0 },'
+  );
+});
+
+test("generateDeclarativeNetRules emits every site-specific URL", () => {
+  const generated = generateDeclarativeNetRules({
+    common: [],
+    common_groups: {},
+    specific: {
+      "example.com": ["first-filter", "second-filter"],
+      "another.example": ["another-filter"],
+    },
+  });
+
+  assert.deepEqual(
+    generated.map(({ id, condition }) => ({ id, ...condition })),
+    [
+      {
+        id: 1,
+        urlFilter: "first-filter",
+        resourceTypes: ["script", "stylesheet", "xmlhttprequest", "image"],
+        initiatorDomains: ["example.com"],
+      },
+      {
+        id: 2,
+        urlFilter: "another-filter",
+        resourceTypes: ["script", "stylesheet", "xmlhttprequest", "image"],
+        initiatorDomains: ["another.example"],
+      },
+      {
+        id: 3,
+        urlFilter: "second-filter",
+        resourceTypes: ["script", "stylesheet", "xmlhttprequest", "image"],
+        initiatorDomains: ["example.com"],
+      },
+    ]
+  );
+});


### PR DESCRIPTION
## Summary

- generate a Manifest V3 rule for every site-specific URL filter
- preserve the IDs of all existing generated rules and append the six recovered filters
- allow the rule helper to write valid common/handler index `0`
- add focused regression tests for both cases

## Root cause

The Manifest V3 generator used only the first URL in each site-specific filter array. Six domains currently have a second filter, so Chrome and Edge missed rules that the Manifest V2 runtime applies.

The add-rule helper used truthiness checks for numeric rule references, which discarded the valid `0` index even though the CLI accepted it.

## Checks

- `npm test`
- `npm run lint`
- `npm run prettier`
- `npm run generate-block-rules`
- verified all 531 site-specific domain/filter pairs are present
- verified existing generated rules and IDs 1–1734 are unchanged
