### PR TITLE
Fix inherited whitelist toggles

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Get rid of cookie warnings from almost all websites!",
   "main": "index.js",
   "scripts": {
+    "test": "node --test",
     "lint": "eslint src .",
     "lintfix": "eslint src --fix",
     "prettier": "prettier --write .",

--- a/src/data/background.js
+++ b/src/data/background.js
@@ -131,16 +131,14 @@ async function toggleWhitelist(tab) {
   }
 
   if (tabList[tab.id].whitelisted) {
-    // const hostname = getWhitelistedDomain(tabList[tab.id]);
-    delete settings.whitelistedDomains[tabList[tab.id].hostname];
+    const hostname = getWhitelistedDomain(tabList[tab.id]);
+    delete settings.whitelistedDomains[hostname];
   } else {
     settings.whitelistedDomains[tabList[tab.id].hostname] = true;
   }
   chrome.storage.local.set({ settings }, function () {
     for (const i in tabList) {
-      if (tabList[i].hostname == tabList[tab.id].hostname) {
-        tabList[i].whitelisted = !tabList[tab.id].whitelisted;
-      }
+      tabList[i].whitelisted = isWhitelisted(tabList[i]);
     }
   });
   if (isManifestV3) {

--- a/tools/background.test.js
+++ b/tools/background.test.js
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("toggleWhitelist removes the effective parent-domain entry", async () => {
+  let onMessage;
+  let storedSettings = {
+    statusIndicators: true,
+    whitelistedDomains: { "example.com": true },
+  };
+  const tabs = [
+    { id: 1, url: "https://shop.example.com/" },
+    { id: 2, url: "https://blog.example.com/" },
+  ];
+  const event = { addListener() {} };
+
+  globalThis.chrome = {
+    browserAction: {
+      setBadgeText() {},
+      setBadgeBackgroundColor() {},
+    },
+    i18n: { getMessage() {} },
+    notifications: { create() {} },
+    runtime: {
+      getManifest: () => ({ manifest_version: 2 }),
+      lastError: null,
+      onInstalled: event,
+      onMessage: {
+        addListener(listener) {
+          onMessage = listener;
+        },
+      },
+    },
+    storage: {
+      local: {
+        get(defaults, callback) {
+          callback({ settings: structuredClone(storedSettings) });
+        },
+        set({ settings }, callback) {
+          storedSettings = structuredClone(settings);
+          callback();
+        },
+      },
+    },
+    tabs: {
+      create() {},
+      executeScript() {},
+      insertCSS() {},
+      onCreated: event,
+      onRemoved: event,
+      onUpdated: event,
+      query(_query, callback) {
+        callback(structuredClone(tabs));
+      },
+    },
+    webNavigation: {
+      onCommitted: event,
+      onCompleted: event,
+    },
+    webRequest: {
+      onBeforeRequest: event,
+      onHeadersReceived: event,
+    },
+  };
+
+  await import("../src/data/background.js");
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const sendMessage = (request) =>
+    new Promise((resolve) => {
+      assert.equal(onMessage(request, {}, resolve), true);
+    });
+
+  const before = await sendMessage({ command: "get_active_tab", tabId: 1 });
+  assert.equal(before.tab.whitelisted, true);
+  assert.equal(before.tab.hostname, "example.com");
+
+  await sendMessage({ command: "toggle_extension", tabId: 1 });
+  assert.deepEqual(storedSettings.whitelistedDomains, {});
+
+  const activeTab = await sendMessage({ command: "get_active_tab", tabId: 1 });
+  const siblingTab = await sendMessage({ command: "get_active_tab", tabId: 2 });
+  assert.equal(activeTab.tab.whitelisted, false);
+  assert.equal(siblingTab.tab.whitelisted, false);
+});


### PR DESCRIPTION
## Summary

- remove the effective whitelist entry when a subdomain inherits its disabled state from a parent domain
- recompute cached tab states after a whitelist change so sibling subdomains stay consistent
- add a mocked Chrome runtime regression test for the complete popup message flow

## Root cause

Every runtime message rebuilds the tab cache. When `example.com` was whitelisted and the active tab was `shop.example.com`, the toggle path tried to delete `shop.example.com` instead of the effective `example.com` entry. The stored parent entry remained, so the toolbar could not re-enable the extension on that subdomain.

## Checks

- `npm test`
- `npm run lint`
- `npx prettier --check package.json src/data/background.js tools/background.test.js`
- verified the regression test fails against `origin/master` and passes with this fix
