### PR TITLE
Fix incomplete Slovak translation

### DIFF
--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -96,7 +96,7 @@
     "description": "Notes for the report"
   },
   "reportNotesPlaceholder": {
-    "message": "Napríklad:\nPrehrávanie videa nefunguje\nRozbitý posuvník\nSivý prekryv",
+    "message": "Things like:\nVideoplayback not working\nBroken scrollbar\ngray overlay",
     "description": "Placeholder for the notes (\n) is a new line & keep it 4 lines"
   },
   "reportAnonSend": {
@@ -124,23 +124,23 @@
     "description": "Loading messsage"
   },
   "generalIssueOption": {
-    "message": "Všeobecný problém (vyžaduje poznámky)",
+    "message": "General issue (requires notes)",
     "description": "The option text for a general issue"
   },
   "scrollbarIssueOption": {
-    "message": "Súvisiace s posuvníkom",
+    "message": "Scrollbar related",
     "description": "The option text for a scrollbar issue"
   },
   "modalIssueOption": {
-    "message": "Súvisiace s modálnym oknom",
+    "message": "Modal related",
     "description": "The option text for a modal issue"
   },
   "scrollbarIssueDescription": {
-    "message": "Vyberte túto možnosť, ak chcete označiť problém na tejto stránke súvisiaci s posúvaním - napríklad „stránka nezobrazuje posuvník“.",
+    "message": "Select this option to signify an issue on this page related to scrolling - like 'the site is not showing a scrollbar'.",
     "description": "Explanation of what a scrollbar issue is"
   },
   "modalIssueDescription": {
-    "message": "Vyberte túto možnosť, ak chcete označiť problém na tejto stránke súvisiaci s modálnym oknom - napríklad „vyskakovacie okno blokuje interakciu“.",
+    "message": "Select this option to signify an issue on this page related to a modal - like 'there is a pop-up box blocking interaction'.",
     "description": "Explanation of what a modal issue is"
   }
 }

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -96,7 +96,7 @@
     "description": "Notes for the report"
   },
   "reportNotesPlaceholder": {
-    "message": "Things like:\nVideoplayback not working\nBroken scrollbar\ngray overlay",
+    "message": "Napríklad:\nPrehrávanie videa nefunguje\nRozbitý posuvník\nSivý prekryv",
     "description": "Placeholder for the notes (\n) is a new line & keep it 4 lines"
   },
   "reportAnonSend": {
@@ -124,23 +124,23 @@
     "description": "Loading messsage"
   },
   "generalIssueOption": {
-    "message": "General issue (requires notes)",
+    "message": "Všeobecný problém (vyžaduje poznámky)",
     "description": "The option text for a general issue"
   },
   "scrollbarIssueOption": {
-    "message": "Scrollbar related",
+    "message": "Súvisiace s posuvníkom",
     "description": "The option text for a scrollbar issue"
   },
   "modalIssueOption": {
-    "message": "Modal related",
+    "message": "Súvisiace s modálnym oknom",
     "description": "The option text for a modal issue"
   },
   "scrollbarIssueDescription": {
-    "message": "Select this option to signify an issue on this page related to scrolling - like 'the site is not showing a scrollbar'.",
+    "message": "Vyberte túto možnosť, ak chcete označiť problém na tejto stránke súvisiaci s posúvaním - napríklad „stránka nezobrazuje posuvník“.",
     "description": "Explanation of what a scrollbar issue is"
   },
   "modalIssueDescription": {
-    "message": "Select this option to signify an issue on this page related to a modal - like 'there is a pop-up box blocking interaction'.",
+    "message": "Vyberte túto možnosť, ak chcete označiť problém na tejto stránke súvisiaci s modálnym oknom - napríklad „vyskakovacie okno blokuje interakciu“.",
     "description": "Explanation of what a modal issue is"
   }
 }


### PR DESCRIPTION
## Summary
- Several strings in `src/_locales/sk/messages.json` were left untranslated (copied verbatim from the English source): `reportNotesPlaceholder`, `generalIssueOption`, `scrollbarIssueOption`, `modalIssueOption`, `scrollbarIssueDescription`, `modalIssueDescription`.
- Translated them to Slovak. All 30 keys now match `en/messages.json` 1:1 (verified programmatically, no missing/extra keys).
- `extensionName` intentionally left in English, matching the convention used across all other locales (cs, de, fr, pl, ...).

## Test plan
- [x] Verified `sk/messages.json` is valid JSON.
- [x] Diffed keys against `en/messages.json`: no missing/extra keys.
- [x] Diffed message values against `en/messages.json`: no remaining untranslated strings (aside from `extensionName`, kept by convention).